### PR TITLE
fix/update-skills

### DIFF
--- a/src/components/UpdateProfileForm/UpdateProfileForm.jsx
+++ b/src/components/UpdateProfileForm/UpdateProfileForm.jsx
@@ -296,7 +296,7 @@ function UserUpdateForm({editing, setEditing}) {
                 <label htmlFor="skills" className="label-checkbox">
                   Select skills{" "}
                 </label>
-                <div className="skills-checkbox-container">
+                <div className="skills-checkbox-container skills">
                   {skills.map((item, index) => (
                     <div key={index} className="mini-checkbox-container">
                       <input

--- a/src/components/UpdateProfileForm/UpdateProfileForm.jsx
+++ b/src/components/UpdateProfileForm/UpdateProfileForm.jsx
@@ -54,6 +54,8 @@ function UserUpdateForm({editing, setEditing}) {
     };
 
     formData.skills = Array.from(document.querySelectorAll('.skills input[type="checkbox"]:checked')).map(x => x.value)
+    // Here we are querying the DOM to select elements in the skills class that are input types of checkbox with a value of checked.
+    // This is to ensure a successful PUT request, as, without the list of skills, the PUT request will fail.
 
     const handleCheckboxChange = (event) => {
       let updatedList = [...checkedState];
@@ -296,7 +298,8 @@ function UserUpdateForm({editing, setEditing}) {
                 <label htmlFor="skills" className="label-checkbox">
                   Select skills{" "}
                 </label>
-                <div className="skills-checkbox-container skills">
+                <div className="skills-checkbox-container skills"> {/* The skills class is used to pull the checkbox information from 
+                the DOM to ensure skill data is submitted in the PUT request. Without this information, the PUT request will fail */}
                   {skills.map((item, index) => (
                     <div key={index} className="mini-checkbox-container">
                       <input


### PR DESCRIPTION
Adding skills class back in to ensure update profile form submits.
This class is used to query the DOM and update the formData.skills property to ensure skills are successfully submitted in the PUT request, which will otherwise not work.

This fix should be deployed to main straight away, if review is approved into development.